### PR TITLE
chore: add Mockito dependencies for unit testing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,4 +59,6 @@ dependencies {
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)
     testImplementation("io.qameta.allure:allure-junit5:2.24.0")
+    testImplementation("org.mockito:mockito-core:5.12.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.12.0")
 }


### PR DESCRIPTION
## 📌 Description

Adds Mockito support to the project test environment to improve unit test isolation and simplify dependency mocking in domain and business logic tests.

---

## ✅ What was done

- Added `mockito-core` dependency
- Added `mockito-junit-jupiter` dependency
- Integrated Mockito with JUnit 5
- Enabled mocking support using:
  - `mock()`
  - `when()`
  - `verify()`
- Validated compatibility with existing test setup

---

## 🧪 Tests

- Verified Mockito dependency integration
- Validated mock creation and behavior stubbing
- Confirmed interaction verification support
- Ensured existing tests continue passing

---

## 🔗 Issue

Closes #11